### PR TITLE
Update the version of nokogiri to a safe version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     hitimes (1.2.2)
     html-pipeline (1.9.0)
       activesupport (>= 2)
-      nokogiri (~> 1.8.1)
+      nokogiri (~> 1.8.2)
     i18n (0.7.0)
     jekyll (2.4.0)
       classifier-reborn (~> 2.0)


### PR DESCRIPTION
Note that I'm not certain from reading the html-pipeline gemfile
and documentation whether we need nokogiri for the filters we use.
It appears that nokogiri might be optional. See:
https://www.rubydoc.info/gems/html-pipeline/frames#Dependencies